### PR TITLE
Only extract product-info.json of downloaded archive

### DIFF
--- a/roles/common/tasks/setup/always.yml
+++ b/roles/common/tasks/setup/always.yml
@@ -37,7 +37,7 @@
       register: jetbrains_common_temporary_directory
       changed_when: "jetbrains_common_temporary_directory is changed and 'molecule-idempotence-notest' not in ansible_skip_tags"
 
-    - name: Extract downloaded file
+    - name: Extract only product-info.json from downloaded file
       become: true
       ansible.builtin.unarchive:
         src: /tmp/{{ jetbrains_common_name }}{{ jetbrains_common_edition }}-{{ jetbrains_common_version }}.tar.gz
@@ -45,6 +45,8 @@
         remote_src: true
         extra_opts:
           - --strip-components=1
+          - --no-anchored
+          - product-info.json
       register: jetbrains_extract_temporary_directory
       changed_when: "jetbrains_extract_temporary_directory is changed and 'molecule-idempotence-notest' not in ansible_skip_tags"
 
@@ -65,6 +67,15 @@
           ansible.builtin.file:
             path: "/opt/{{ jetbrains_common_name }}"
             state: absent
+
+        - name: Extract downloaded file
+          become: true
+          ansible.builtin.unarchive:
+            src: /tmp/{{ jetbrains_common_name }}{{ jetbrains_common_edition }}-{{ jetbrains_common_version }}.tar.gz
+            dest: /tmp/{{ jetbrains_common_name }}{{ jetbrains_common_edition }}-{{ jetbrains_common_version }}
+            remote_src: true
+            extra_opts:
+              - --strip-components=1
 
         - name: Copy temporary directory to permanent location
           become: true


### PR DESCRIPTION
This is in regard to issue #1.
We are preventing double space occupation on the hard drive of the machine extracting the release archive.

There are multiple ways to achieve this:

This is the ansible way:

```yaml
        remote_src: true
        include:
          - */product-info.json
        extra_opts:
          - --strip-components=1
```

Which would translate to

```
            "/usr/bin/gtar",
            "--extract",
            "-C",
            "/tmp/ideaIU-2023.3.1",
            "-z",
            "--show-transformed-names",
            "--strip-components=1",
            "-f",
            "/tmp/ideaIU-2023.3.1.tar.gz",
            "*/product-info.json"
```

In this setup `*` would match everything including `/`.
I am not 100% sure if `--wildcards` somehow gets implicitly set, because the manual for gnu tar (https://www.gnu.org/software/tar/manual/html_section/wildcards.html) says that default for inclusion is `--no-wildcard`

My solution `--no-anchored` just searches for the given filename anywhere in the archive. This _should_ be the same behaviour as described above in a less `ansible` way, but more reliable functional.

Of course this does not work zip archives etc. There `unarchive`'s `include` would be more suited to do the job. But since we are working with `tar` files only for now (extension `tar.gz`) and therefore only use `tar`, I would say it is okay to use that option.
Also `--strip-components` is `tar`-only AFAIK.